### PR TITLE
Remove top level shell in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize]
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   test:
     name: ${{ matrix.os }}-node-${{ matrix.node }}


### PR DESCRIPTION
Make sure the shell used in the Windows CI run is PowerShell (which is the default for Windows images)